### PR TITLE
Fix user lookup and TMDB fallback

### DIFF
--- a/backend/services/mcp.js
+++ b/backend/services/mcp.js
@@ -5,7 +5,10 @@ const usersPath = path.join(__dirname, "../data/users.json");
 
 function buildMCPContext(userName, userMood, movieList) {
   const users = JSON.parse(fs.readFileSync(usersPath, "utf-8"));
-  const user = users.find(u => u.name === userName);
+  // find the user by name, case-insensitive and trimmed to avoid common
+  // issues with user input
+  const normalizedName = userName.trim().toLowerCase();
+  const user = users.find(u => u.name.toLowerCase() === normalizedName);
 
   if (!user) throw new Error("User not found");
 

--- a/backend/services/tmdb.js
+++ b/backend/services/tmdb.js
@@ -4,17 +4,43 @@ require("dotenv").config();
 const TMDB_API_KEY = process.env.TMDB_API_KEY;
 const BASE_URL = "https://api.themoviedb.org/3";
 
-async function fetchPopularSciFiMovies() {
-  const response = await axios.get(`${BASE_URL}/discover/movie`, {
-    params: {
-      api_key: TMDB_API_KEY,
-      sort_by: "popularity.desc",
-      with_genres: 878, // Sci-Fi genre ID
-      language: "en-US"
-    },
-  });
+// Minimal fallback dataset when an API key isn't provided or the request
+// fails. This keeps development running without network credentials.
+const FALLBACK_MOVIES = [
+  {
+    title: "Interstellar",
+    release_date: "2014-11-05",
+    overview: "A team of explorers travel through a wormhole in space in an attempt to ensure humanity's survival."
+  },
+  {
+    title: "The Matrix",
+    release_date: "1999-03-31",
+    overview: "A computer hacker learns about the true nature of his reality and his role in the war against its controllers."
+  }
+];
 
-  return response.data.results.slice(0, 5); // Just the top 5 for now
+async function fetchPopularSciFiMovies() {
+  // If no API key is present, immediately return the fallback list
+  if (!TMDB_API_KEY) {
+    return FALLBACK_MOVIES;
+  }
+
+  try {
+    const response = await axios.get(`${BASE_URL}/discover/movie`, {
+      params: {
+        api_key: TMDB_API_KEY,
+        sort_by: "popularity.desc",
+        with_genres: 878, // Sci-Fi genre ID
+        language: "en-US",
+      },
+    });
+
+    return response.data.results.slice(0, 5); // Just the top 5 for now
+  } catch (err) {
+    // Network or API errors shouldn't prevent development use
+    console.error("TMDB request failed, using fallback data:", err.message);
+    return FALLBACK_MOVIES;
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- handle case-insensitive user search in `buildMCPContext`
- provide fallback movie list when TMDB API is unavailable

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node backend/index.js` & manual `curl` requests

------
https://chatgpt.com/codex/tasks/task_e_6847e1ede5e4832993c576b005afdfb7