### PR TITLE
Add mood-based movie recommendation to frontend

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -18,3 +18,16 @@ document.getElementById("profile-form").addEventListener("submit", async (e) => 
   const data = await res.json();
   document.getElementById("profile-response").textContent = data.message;
 });
+
+document.getElementById("rec-btn").addEventListener("click", async () => {
+  const name = document.querySelector("input[name='name']").value;
+  const mood = document.getElementById("mood-input").value;
+
+  if (!name) return;
+
+  const res = await fetch(
+    `http://localhost:3000/api/recommend/${encodeURIComponent(name)}?mood=${encodeURIComponent(mood)}`
+  );
+  const data = await res.json();
+  document.getElementById("recommendation").textContent = data.recommendation;
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,9 +4,12 @@
   <label>Preferred Genres (comma-separated): <input type="text" name="genres" /></label><br />
   <label>Preferred Languages: <input type="text" name="languages" /></label><br />
   <label>Disliked Genres: <input type="text" name="dislikes" /></label><br />
+  <label>Mood: <input type="text" id="mood-input" name="mood" /></label><br />
   <button type="submit">Save Profile</button>
+  <button type="button" id="rec-btn">Get Recommendation</button>
 </form>
 
 <div id="profile-response"></div>
+<div id="recommendation"></div>
 
 <script src="app.js"></script>


### PR DESCRIPTION
## Summary
- extend profile form with a mood input
- add a "Get Recommendation" button
- fetch movie suggestions from `/api/recommend/:name` with mood
- show the returned recommendation in the page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847f2628f0883299a94baa5acde9ac6