### PR TITLE
Add glassmorphism style to frontend

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,17 +1,30 @@
 body {
-  background-color: #f5f5f5;
+  background: linear-gradient(135deg, #dbeafe, #f0f9ff);
   font-family: 'Inter', 'Segoe UI', sans-serif;
   padding: 2rem;
   max-width: 800px;
   margin: auto;
+  color: #1f2937;
 }
 
-form {
-  background-color: white;
+form,
+.recommendation-card,
+.movie-card {
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.1);
+  transition: box-shadow 0.2s ease-in-out;
   padding: 1.5rem;
-  border-radius: 10px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
   margin-bottom: 2rem;
+}
+
+form:hover,
+.recommendation-card:hover,
+.movie-card:hover {
+  box-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.2);
 }
 
 .section {
@@ -39,17 +52,18 @@ input, select, textarea {
 
 button {
   padding: 0.75rem 1.5rem;
-  background-color: #0070f3;
+  background: rgba(0, 112, 243, 0.6);
   color: white;
   border: none;
-  border-radius: 5px;
+  border-radius: 12px;
   cursor: pointer;
   margin-right: 5px;
   font-size: 14px;
+  transition: background 0.2s ease-in-out;
 }
 
 button:hover {
-  background-color: #005fcc;
+  background: rgba(0, 95, 204, 0.75);
 }
 
 .message {
@@ -64,9 +78,6 @@ button:hover {
 }
 
 .movie-card {
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
   padding: 15px;
   width: 200px;
 }
@@ -78,11 +89,8 @@ button:hover {
 }
 
 .recommendation-card {
-  background-color: white;
   border-left: 5px solid #0070f3;
   padding: 1rem;
-  border-radius: 8px;
-  box-shadow: 0 1px 6px rgba(0,0,0,0.1);
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- modernize the UI with a light gradient background
- add glass-like styles to the form and recommendation cards
- refresh button styling with smooth hover transitions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68495b51984c8329905132aee7043903