### PR TITLE
Implement genre-based movie search and health ping

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -15,6 +15,9 @@ const genreRoutes = require("./routes/genres");
 app.use("/api/movies", movieRoutes);
 app.use("/api/recommend", recommendRoutes);
 app.use("/api/genres", genreRoutes);
+app.get("/api/ping", (req, res) => {
+  res.json({ ok: true });
+});
 
 // (Optional) Serve frontend
 app.use(express.static(path.join(__dirname, "../frontend")));

--- a/backend/routes/movie.js
+++ b/backend/routes/movie.js
@@ -1,10 +1,11 @@
 const express = require("express");
 const router = express.Router();
-const { fetchPopularSciFiMovies } = require("../services/tmdb");
+const { fetchMoviesByGenres } = require("../services/tmdb");
 
-router.get("/sci-fi", async (req, res) => {
+router.post("/by-genres", async (req, res) => {
+  const { genres = [] } = req.body;
   try {
-    const movies = await fetchPopularSciFiMovies();
+    const movies = await fetchMoviesByGenres(genres);
     res.json(movies);
   } catch (err) {
     res.status(500).json({ error: "Failed to fetch movies." });

--- a/backend/routes/recommend.js
+++ b/backend/routes/recommend.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const router = express.Router();
-const { fetchPopularSciFiMovies } = require("../services/tmdb");
+const { fetchMoviesByGenres } = require("../services/tmdb");
 const { buildMCPContext } = require("../services/mcp");
 const { getMovieRecommendation } = require("../services/openai");
 
@@ -11,7 +11,13 @@ router.post("/", async (req, res) => {
   console.log("[Route] /api/recommend request:", preferences);
 
   try {
-    const movies = await fetchPopularSciFiMovies(); // later: fetch by genres
+    let movies;
+    if (genres.length === 0) {
+      console.log("[Route] No genres provided, using fallback movies");
+      movies = await fetchMoviesByGenres();
+    } else {
+      movies = await fetchMoviesByGenres(genres);
+    }
     const context = buildMCPContext(preferences, movies);
     console.log("[Route] Built MCP context for OpenAI");
     let recommendation;


### PR DESCRIPTION
## Summary
- add health check endpoint `/api/ping`
- switch `/api/movies` to dynamic `/by-genres` route
- fetch movies by genre when recommending
- implement `fetchMoviesByGenres` helper in tmdb service

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68498224d0cc8329907bfbea464b3f26