### PR TITLE
Limit OpenAI response logging

### DIFF
--- a/backend/services/openai.js
+++ b/backend/services/openai.js
@@ -16,7 +16,10 @@ async function getMovieRecommendation(prompt) {
       max_tokens: 400
     });
 
-    console.log("[OpenAI] Raw response:", JSON.stringify(response));
+    console.log(
+      "[OpenAI] Response message:",
+      JSON.stringify(response.choices[0].message)
+    );
     const recommendation = response.choices[0].message.content;
     console.log("[OpenAI] Recommendation:", recommendation);
     return recommendation;


### PR DESCRIPTION
## Summary
- stop logging the entire OpenAI response
- only log the message section

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68498ff9211c8329918e447254b6e5eb