### PR TITLE
Remove unused Sci-Fi movie route

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You should see an assembled MCP prompt including your preferences and movie data
 cinemcp/
 ├── backend/
 │   ├── routes/
-│   │   ├── movie.js            # GET /api/movies/sci-fi - TMDB fetcher
+│   │   ├── movie.js            # POST /api/movies/by-genres - TMDB fetcher
 │   │   └── recommend.js        # POST /api/recommend - MCP assembler
 │   ├── services/
 │   │   ├── mcp.js              # Builds final context string for OpenAI

--- a/backend/services/tmdb.js
+++ b/backend/services/tmdb.js
@@ -34,33 +34,6 @@ const FALLBACK_GENRES = [
   { id: 878, name: "Sci-Fi" },
 ];
 
-async function fetchPopularSciFiMovies() {
-  // If no API key is present, immediately return the fallback list
-  if (!TMDB_API_KEY) {
-    console.log("[TMDB] No API key, using fallback movies");
-    return FALLBACK_MOVIES;
-  }
-
-  try {
-    console.log("[TMDB] Fetching popular Sci-Fi movies");
-    const response = await axios.get(`${BASE_URL}/discover/movie`, {
-      params: {
-        api_key: TMDB_API_KEY,
-        sort_by: "popularity.desc",
-        with_genres: 878, // Sci-Fi genre ID
-        language: "en-US",
-      },
-    });
-
-    const results = response.data.results.slice(0, 5); // Just the top 5 for now
-    console.log(`[TMDB] Retrieved ${results.length} movies`);
-    return results;
-  } catch (err) {
-    // Network or API errors shouldn't prevent development use
-    console.error("TMDB request failed, using fallback data:", err.message);
-    return FALLBACK_MOVIES;
-  }
-}
 
 async function fetchGenres() {
   if (!TMDB_API_KEY) {
@@ -128,7 +101,6 @@ async function fetchMoviesByGenres(genreNames = []) {
 }
 
 module.exports = {
-  fetchPopularSciFiMovies,
   fetchGenres,
   fetchMoviesByGenres,
 };


### PR DESCRIPTION
## Summary
- clean up folder structure note about movie route
- remove `/api/movies/sci-fi` endpoint
- drop `fetchPopularSciFiMovies` helper and export

## Testing
- `npm install`
- `node backend/index.js` *(fails: OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_68498fdd93d48329bc71fb2a917106c7