### PR TITLE
Improve recommendation display

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -114,7 +114,7 @@ document.getElementById('reset-btn').addEventListener('click', () => {
   });
   document.getElementById('recommendation-box').innerHTML = '';
   document.getElementById('movie-grid').innerHTML = '';
-  document.getElementById('recommended-title').style.display = 'none';
+  document.getElementById('movie-section-title').style.display = 'none';
   document.getElementById('refresh-btn').style.display = 'none';
 });
 
@@ -139,12 +139,23 @@ document.getElementById('refresh-btn').addEventListener('click', async () => {
 function showRecommendation(data) {
   const recommendationBox = document.getElementById('recommendation-box');
   const movieGrid = document.getElementById('movie-grid');
-  document.getElementById('recommended-title').style.display = 'block';
+  const sectionTitle = document.getElementById('movie-section-title');
   document.getElementById('refresh-btn').style.display = 'block';
-  recommendationBox.innerHTML = `\n  <div class="recommendation-card">\n    <h3>🎬 Recommendation</h3>\n    <p>${data.recommendation || ''}</p>\n  </div>\n`;
-  movieGrid.innerHTML = '';
 
-  if (Array.isArray(data.movies)) {
+  recommendationBox.innerHTML = `
+    <div class="recommendation-card">
+      <h3>🎬 AI Recommendation</h3>
+      <p>${data.recommendation || ''}</p>
+    </div>
+    <hr class="section-divider">
+  `;
+
+  movieGrid.innerHTML = '';
+  sectionTitle.textContent = 'More popular movies in your selected genre:';
+  sectionTitle.style.display = 'none';
+
+  if (Array.isArray(data.movies) && data.movies.length > 0) {
+    sectionTitle.style.display = 'block';
     data.movies.forEach(movie => {
       const card = document.createElement('div');
       card.className = 'movie-card';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -33,7 +33,7 @@
   </form>
   <section id="recommendation-wrapper">
     <div id="recommendation-box"></div>
-    <h3 id="recommended-title" style="display:none;">🎬 Recommended Movies</h3>
+    <h4 id="movie-section-title" class="movie-section-label" style="display:none;"></h4>
     <div id="movie-grid"></div>
     <button type="button" id="refresh-btn" style="display:none;">🔁 Refresh</button>
   </section>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -114,6 +114,20 @@ button:hover {
   gap: 20px;
 }
 
+.movie-section-label {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: #374151;
+  padding-left: 0.5rem;
+}
+
+.section-divider {
+  border: none;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  margin: 1.5rem 0;
+}
+
 .movie-card {
   padding: 15px;
   width: 200px;


### PR DESCRIPTION
## Summary
- show an AI recommendation card followed by a divider
- introduce `movie-section-title` heading for extra movies
- style the heading and divider
- hide the heading when resetting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849a0b7b1108329ac1a1e97d8fdb5ee