### PR TITLE
Add loading spinner and genre colors

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5,6 +5,18 @@ const API_BASE =
 
 let lastRequestBody = null;
 
+function showLoading() {
+  document.getElementById('loading').style.display = 'flex';
+  document.getElementById('rec-btn').disabled = true;
+  document.getElementById('refresh-btn').disabled = true;
+}
+
+function hideLoading() {
+  document.getElementById('loading').style.display = 'none';
+  document.getElementById('rec-btn').disabled = false;
+  document.getElementById('refresh-btn').disabled = false;
+}
+
 async function loadGenres() {
   try {
     const res = await fetch(`${API_BASE}/api/genres`);
@@ -23,6 +35,7 @@ async function loadGenres() {
       label1.textContent = g.name;
 
       const wrapper1 = document.createElement('div');
+      wrapper1.className = 'preferred';
       wrapper1.appendChild(cb1);
       wrapper1.appendChild(label1);
 
@@ -39,6 +52,7 @@ async function loadGenres() {
       label2.textContent = g.name;
 
       const wrapper2 = document.createElement('div');
+      wrapper2.className = 'disliked';
       wrapper2.appendChild(cb2);
       wrapper2.appendChild(label2);
 
@@ -80,6 +94,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
 document.getElementById('rec-btn').addEventListener('click', async () => {
+  showLoading();
   const genres = Array.from(document.querySelectorAll("input[name='genres']:checked"))
     .map(cb => cb.value);
   const dislikes = Array.from(document.querySelectorAll("input[name='dislikes']:checked"))
@@ -103,6 +118,8 @@ document.getElementById('rec-btn').addEventListener('click', async () => {
   } catch (err) {
     console.error('[Frontend] Recommendation request failed', err);
     document.getElementById('recommendation-box').textContent = 'Error fetching recommendation';
+  } finally {
+    hideLoading();
   }
 });
 
@@ -116,10 +133,12 @@ document.getElementById('reset-btn').addEventListener('click', () => {
   document.getElementById('movie-grid').innerHTML = '';
   document.getElementById('movie-section-title').style.display = 'none';
   document.getElementById('refresh-btn').style.display = 'none';
+  hideLoading();
 });
 
 document.getElementById('refresh-btn').addEventListener('click', async () => {
   if (!lastRequestBody) return;
+  showLoading();
   try {
     console.log('[Frontend] Refreshing recommendation with', lastRequestBody);
     const res = await fetch(`${API_BASE}/api/recommend`, {
@@ -133,6 +152,8 @@ document.getElementById('refresh-btn').addEventListener('click', async () => {
   } catch (err) {
     console.error('[Frontend] Refresh request failed', err);
     document.getElementById('recommendation-box').textContent = 'Error fetching recommendation';
+  } finally {
+    hideLoading();
   }
 });
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -32,6 +32,10 @@
     <button type="button" id="reset-btn">Reset</button>
   </form>
   <section id="recommendation-wrapper">
+    <div id="loading" class="loading" style="display:none;">
+      <div class="spinner"></div>
+      <span>Fetching recommendations…</span>
+    </div>
     <div id="recommendation-box"></div>
     <h4 id="movie-section-title" class="movie-section-label" style="display:none;"></h4>
     <div id="movie-grid"></div>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -78,6 +78,25 @@ form:hover,
   border: 1px solid rgba(0, 112, 243, 0.5);
 }
 
+/* Preferred/disliked genre distinctions */
+.preferred label {
+  border-color: rgba(34, 197, 94, 0.3);
+}
+
+.preferred input[type="checkbox"]:checked + label {
+  background: rgba(34, 197, 94, 0.8);
+  border-color: rgba(34, 197, 94, 0.5);
+}
+
+.disliked label {
+  border-color: rgba(239, 68, 68, 0.3);
+}
+
+.disliked input[type="checkbox"]:checked + label {
+  background: rgba(239, 68, 68, 0.8);
+  border-color: rgba(239, 68, 68, 0.5);
+}
+
 label {
   display: block;
   margin-bottom: 0.5rem;
@@ -110,6 +129,11 @@ button:hover {
 
 button:active {
   transform: scale(0.97);
+}
+
+button:disabled {
+  background: rgba(0, 112, 243, 0.4);
+  cursor: not-allowed;
 }
 
 .message {
@@ -236,4 +260,26 @@ button:active {
 
 .cta-btn:hover {
   background: #1d4ed8;
+}
+
+/* Loading indicator */
+.loading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  font-weight: bold;
+}
+
+.spinner {
+  width: 20px;
+  height: 20px;
+  border: 3px solid rgba(0, 0, 0, 0.2);
+  border-top-color: rgba(0, 112, 243, 0.8);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }


### PR DESCRIPTION
## Summary
- add loading spinner section to the page
- show/hide loading indicator during fetch
- style preferred and disliked genres with green/red accents
- dim buttons while disabled

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a8910f56c8329892d1fe0be19dffc