### PR TITLE
Fix language filter

### DIFF
--- a/backend/routes/recommend.js
+++ b/backend/routes/recommend.js
@@ -14,9 +14,9 @@ router.post("/", async (req, res) => {
     let movies;
     if (genres.length === 0) {
       console.log("[Route] No genres provided, using fallback movies");
-      movies = await fetchMoviesByGenres();
+      movies = await fetchMoviesByGenres([], languages);
     } else {
-      movies = await fetchMoviesByGenres(genres);
+      movies = await fetchMoviesByGenres(genres, languages);
     }
     const context = buildMCPContext(preferences, movies);
     console.log("[Route] Built MCP context for OpenAI");


### PR DESCRIPTION
## Summary
- add language code mapping to TMDB service
- filter fallback movies and TMDB requests by selected language
- send selected languages to TMDB when recommending movies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fbe2aefe483299ddb2ecfe6e33eeb