### PR TITLE
Add sorting and min year filters

### DIFF
--- a/__tests__/recommend.test.js
+++ b/__tests__/recommend.test.js
@@ -14,7 +14,7 @@ describe('/api/recommend route', () => {
   test('responds with recommendation and movies', async () => {
     const res = await request(app)
       .post('/api/recommend')
-      .send({ genres: ['Sci-Fi'] });
+      .send({ genres: ['Sci-Fi'], sort: 'vote_average.desc', minYear: 2000 });
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('recommendation');
     expect(res.body).toHaveProperty('movies');

--- a/__tests__/services.test.js
+++ b/__tests__/services.test.js
@@ -28,7 +28,7 @@ describe('buildMCPContext', () => {
 
 describe('fetchMoviesByGenres', () => {
   test('returns fallback movies when no API key present', async () => {
-    const movies = await fetchMoviesByGenres(['Sci-Fi']);
+    const movies = await fetchMoviesByGenres(['Sci-Fi'], [], 'vote_average.desc', 1990);
     expect(Array.isArray(movies)).toBe(true);
     expect(movies.length).toBeGreaterThan(0);
     const titles = movies.map(m => m.title);

--- a/backend/routes/movie.js
+++ b/backend/routes/movie.js
@@ -3,9 +3,14 @@ const router = express.Router();
 const { fetchMoviesByGenres } = require("../services/tmdb");
 
 router.post("/by-genres", async (req, res) => {
-  const { genres = [] } = req.body;
+  const {
+    genres = [],
+    languages = [],
+    sort = "popularity.desc",
+    minYear,
+  } = req.body;
   try {
-    const movies = await fetchMoviesByGenres(genres);
+    const movies = await fetchMoviesByGenres(genres, languages, sort, minYear);
     res.json(movies);
   } catch (err) {
     res.status(500).json({ error: "Failed to fetch movies." });

--- a/backend/routes/recommend.js
+++ b/backend/routes/recommend.js
@@ -5,8 +5,15 @@ const { buildMCPContext } = require("../services/mcp");
 const { getMovieRecommendation } = require("../services/openai");
 
 router.post("/", async (req, res) => {
-  const { genres = [], dislikes = [], languages = [], mood = "neutral" } = req.body;
-  const preferences = { genres, dislikes, languages, mood };
+  const {
+    genres = [],
+    dislikes = [],
+    languages = [],
+    mood = "neutral",
+    sort = "popularity.desc",
+    minYear,
+  } = req.body;
+  const preferences = { genres, dislikes, languages, mood, sort, minYear };
 
   console.log("[Route] /api/recommend request:", preferences);
 
@@ -14,9 +21,9 @@ router.post("/", async (req, res) => {
     let movies;
     if (genres.length === 0) {
       console.log("[Route] No genres provided, using fallback movies");
-      movies = await fetchMoviesByGenres([], languages);
+      movies = await fetchMoviesByGenres([], languages, sort, minYear);
     } else {
-      movies = await fetchMoviesByGenres(genres, languages);
+      movies = await fetchMoviesByGenres(genres, languages, sort, minYear);
     }
     const context = buildMCPContext(preferences, movies);
     console.log("[Route] Built MCP context for OpenAI");

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -103,9 +103,12 @@ document.getElementById('rec-btn').addEventListener('click', async () => {
   const languages = Array.from(document.querySelectorAll('.chip.selected'))
     .map(chip => chip.textContent);
   const mood = document.getElementById('mood-input').value;
+  const sort = document.getElementById('sort-select').value;
+  const minYearValue = document.getElementById('min-year').value;
+  const minYear = minYearValue ? parseInt(minYearValue, 10) : undefined;
 
   try {
-    const payload = { genres, dislikes, languages, mood };
+    const payload = { genres, dislikes, languages, mood, sort, minYear };
     console.log('[Frontend] Sending preferences', payload);
     const res = await fetch(`${API_BASE}/api/recommend`, {
       method: 'POST',

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,6 +28,16 @@
     <div class="section">
       <label>Mood: <input type="text" id="mood-input" name="mood"></label>
     </div>
+    <div class="section">
+      <label for="sort-select">Sort by:</label>
+      <select id="sort-select" name="sort">
+        <option value="popularity.desc" selected>Most Popular</option>
+        <option value="vote_average.desc">Highest Rated</option>
+      </select>
+    </div>
+    <div class="section">
+      <label>Minimum Year: <input type="number" id="min-year" name="minYear" min="1900" max="2100"></label>
+    </div>
     <button type="button" id="rec-btn" class="cta-btn">Get Recommendations</button>
     <button type="button" id="reset-btn">Reset</button>
   </form>


### PR DESCRIPTION
## Summary
- add popularity vs rating filter and minimum year support
- update backend TMDB service to accept `sort` and `minYear`
- plumb new params through movie and recommend routes
- extend frontend UI and app.js to send new request fields
- adjust tests for new parameters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68629c8172f08329b8b6b30f4d069036